### PR TITLE
It just wanted to be named smqueue-public, thats all.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
 smqueue-public (5.0) untested; urgency=low
 
-    * Test
+  * Test
 
  -- Range Packager <buildmeister@rangenetworks.com>  Wed, 13 Oct 2014 12:42:00 -0700

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: build-essential, debhelper (>= 7), libtool, pkg-config, autoconf,
 Standards-Version: 3.7.3
 
 Package: smqueue-public
-Provides: smqueue-public
+Provides: smqueue
 Section: comm
 Priority: optional
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -1,17 +1,17 @@
 Source: smqueue-public
 Section: comm
 Priority: optional
-Maintainer: Range Networks, Inc. <info@rangenetworks.com>
-Homepage: http://www.rangenetworks.com/
+Maintainer: Endaga, Inc. <hello@endaga.com>
+Homepage: http://www.endaga.com/
 Build-Depends: build-essential, debhelper (>= 7), libtool, pkg-config, autoconf, libsqlite3-dev, libosip2-dev, libzmq3-dev, libcoredumper1, libcoredumper-dev
 Standards-Version: 3.7.3
 
 Package: smqueue-public
-Provides: smqueue
+Provides: smqueue-public
 Section: comm
 Priority: optional
 Architecture: any
 Essential: no
 Depends: sqlite3, libosip2-4, libc6, pkg-config, libzmq1, supervisor
-Description: Range Networks - SMQueue RFC-3428 Store and Forward Server
+Description: Endaga - SMQueue RFC-3428 Store and Forward Server
 

--- a/debian/rules
+++ b/debian/rules
@@ -75,7 +75,7 @@ install-arch:
 
 	# Add here commands to install the arch part of the package into
 	# debian/{package}.
-	$(MAKE) DESTDIR=$(CURDIR)/debian/smqueue install
+	$(MAKE) DESTDIR=$(CURDIR)/debian/smqueue-public install
 
 	dh_install -s
 
@@ -99,7 +99,7 @@ binary-common:
 #	dh_installcron
 #	dh_installinfo
 	dh_installman
-	dh_link
+#	dh_link
 #	dh_strip
 	dh_compress
 	dh_fixperms


### PR DESCRIPTION
Ok this one works as `smqueue-public` back to `sipauthserve` to find wtf is going on
