### PR TITLE
Add libcoredumper dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,5 +12,5 @@ Section: comm
 Priority: optional
 Architecture: any
 Essential: no
-Depends: sqlite3, libosip2-dev, libc6, pkg-config, libzmq1, supervisor
+Depends: sqlite3, libosip2-dev, libc6, pkg-config, libzmq1, supervisor, libcoredumper1
 Description: Endaga - SMQueue RFC-3428 Store and Forward Server


### PR DESCRIPTION
`libcoredumper1` should be in the package deps, not just build-deps
